### PR TITLE
Improve logic for when there is only one post

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -86,7 +86,7 @@ const BlogPost: FC<BlogPostProps> = ({ blogPost, admin, post, feed }) => {
     (session && session?.user?.email === process.env.NEXT_PUBLIC_USER_EMAIL);
 
   const isFeatured = post.featured;
-  const latestPostID = feed[feed?.length - 1].id;
+  const latestPostID = feed.length > 1 ? feed[feed?.length - 1].id : feed[0];
   const latestPost = latestPostID === post.id;
 
   const isEdited =

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,7 @@ export const getStaticProps: GetStaticProps = async () => {
         select: { title: true, teaser: true, slug: true },
       }),
       prisma.post.findFirst({
-        where: { featured: false, published: true },
+        where: { published: true },
         orderBy: { publishedAt: 'desc' },
         select: { title: true, teaser: true, slug: true },
       }),


### PR DESCRIPTION
- Fixed an issue where an error was thrown on the drafts page in the CMS.
- Fixed an issue where "Latest Post" sometimes did not display correctly