### PR TITLE
fix pageview start date

### DIFF
--- a/pages/api/views/pageviews.ts
+++ b/pages/api/views/pageviews.ts
@@ -22,7 +22,7 @@ export default async function handler(
       property: `properties/${process.env.GOOGLE_ANALYTICS_API_PROPERTY_ID}`,
       dateRanges: [
         {
-          startDate: '2000-01-01',
+          startDate: '2005-01-02',
           endDate: 'today',
         },
       ],

--- a/pages/api/views/postviews.ts
+++ b/pages/api/views/postviews.ts
@@ -29,7 +29,7 @@ export default async function handler(
       ],
       dateRanges: [
         {
-          startDate: '2000-01-01',
+          startDate: '2005-01-02',
           endDate: 'today',
         },
       ],


### PR DESCRIPTION
- fixed an issue where GA4 arbitrarily changed their minimum `start_date` to "greater than 2005-01-01" 🙄